### PR TITLE
Fix Meta 2025 Systemic Risks reports

### DIFF
--- a/declarations/Facebook.history.json
+++ b/declarations/Facebook.history.json
@@ -3,6 +3,10 @@
     {
       "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An_4ZmmuvtZDdTPTnteN1A6nQkJNs31uKukzSrgflCIZHDeAjVQueAfz3j_wRDMaomSTuF7escGwFC2rshGaKzL5ReBjJtmzkRRgUH5wIV7wbqqR9C-8MxdijOmPCKRL6msYoAI?_nc_gid=aBRLLLBv_QETw2hChtW0Sg&_nc_oc=AdpJc0vGnRJv8picecILxvPIsgNmfnZjgHAz7Iu2yJrzFPXzQRfIvwHWFiwYR9LjOsbq706xyRRh9VrImSBx5jDs&ccb=10-5&oh=00_Af4MTefpLOXgmRKlXRiwXXyIa3vaMYATaBmtN2YUN5sv2Q&oe=6A04E47C&_nc_sid=68f2c3#pdf",
       "validUntil": "2026-05-17T04:12:05Z"
+    },
+    {
+      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An_4ZmmuvtZDdTPTnteN1A6nQkJNs31uKukzSrgflCIZHDeAjVQueAfz3j_wRDMaomSTuF7escGwFC2rshGaKzL5ReBjJtmzkRRgUH5wIV7wbqqR9C-8MxdijOmPCKRL6msYoAI?_nc_gid=vI6JC0DrhAYrto-79RvMwA&_nc_oc=Ado4Haf5midjfTlsnYe5jBkC7z8F3vL1nYH6QqVUeRjp8HWjcgI8BrFi4J46ck2mLPI&ccb=10-6&oh=00_Af7byLVoZIIehbKenMCrSphwuSBnOjUIEzqkAIa2OTJeOA&oe=6A0E1EFC&_nc_sid=68f2c3#pdf",
+      "validUntil": "2026-05-24T04:12:37Z"
     }
   ]
 }

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -5,7 +5,7 @@
       "fetch": "https://transparency.meta.com/sr/dsa-sra_results_report-2024-facebook#pdf"
     },
     "Systemic Risks — 2025": {
-      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An_4ZmmuvtZDdTPTnteN1A6nQkJNs31uKukzSrgflCIZHDeAjVQueAfz3j_wRDMaomSTuF7escGwFC2rshGaKzL5ReBjJtmzkRRgUH5wIV7wbqqR9C-8MxdijOmPCKRL6msYoAI?_nc_gid=vI6JC0DrhAYrto-79RvMwA&_nc_oc=Ado4Haf5midjfTlsnYe5jBkC7z8F3vL1nYH6QqVUeRjp8HWjcgI8BrFi4J46ck2mLPI&ccb=10-6&oh=00_Af7byLVoZIIehbKenMCrSphwuSBnOjUIEzqkAIa2OTJeOA&oe=6A0E1EFC&_nc_sid=68f2c3#pdf"
+      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An_4ZmmuvtZDdTPTnteN1A6nQkJNs31uKukzSrgflCIZHDeAjVQueAfz3j_wRDMaomSTuF7escGwFC2rshGaKzL5ReBjJtmzkRRgUH5wIV7wbqqR9C-8MxdijOmPCKRL6msYoAI?_nc_gid=QAut1O1izJ9OebxgGgBIrg&_nc_oc=Adr7hCCFE0yrPgh2WiTsiCncYFFKyyEEjxKFCY5r0_cJwGk6hSYKwuAGHn4ck6Kne9PijJPZ-IATFl5DXtmogzq-&ccb=10-5&oh=00_Af-gtqAEkdz2GgP3n5IPYZ629uRjqkzQ16Q-BdvaJBXAoQ&oe=6A3C437C&_nc_sid=68f2c3#pdf"
     }
   }
 }

--- a/declarations/Instagram.history.json
+++ b/declarations/Instagram.history.json
@@ -3,6 +3,10 @@
     {
       "fetch": "https://scontent-cdg4-3.xx.fbcdn.net/m1/v/t0.84174-6/An8XcdaHXXjKc6ezrgbQR9yoq0DMmtPQrTijRe8MaU67fncOrw-rcDUNuuP0lfpTLGr3aWtYkKlpqwYW6sbYnLPPJHucxd0m4JR00vEuxj1vz7TPa_bKxrrnUCfFz0Jr-Wv0Ibs?_nc_gid=eHV94HKt0koyfsfrSwgwpw&_nc_oc=Adpi0PO1MDY9PFWX49uU11CL3SUWmr-Ck5vUWaH5l2PGTmdNhb_xBcCjkwJ9IBAzBioaOwY4Squ2Vey_jC3touha&ccb=10-5&oh=00_Af5xqwQszx7vUNTFZ2biQ9JN0va8h6nzUdgIy5Fc7qt_OA&oe=6A03DF93&_nc_sid=68f2c3#pdf",
       "validUntil": "2026-05-17T04:12:06Z"
+    },
+    {
+      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An8XcdaHXXjKc6ezrgbQR9yoq0DMmtPQrTijRe8MaU67fncOrw-rcDUNuuP0lfpTLGr3aWtYkKlpqwYW6sbYnLPPJHucxd0m4JR00vEuxj1vz7TPa_bKxrrnUCfFz0Jr-Wv0Ibs?_nc_gid=vI6JC0DrhAYrto-79RvMwA&_nc_oc=AdrENnQCME4XvD4qyiEbcRtLiwnjDqrfpEICxtu8z2z_3TYCFkDO8ydww13hbrN0Urk&ccb=10-5&oh=00_Af6SSxrui4wgoDdyBg18dWvnkfQcT72X_zGcSB3WGdiLHw&oe=6A0E3353&_nc_sid=68f2c3#pdf",
+      "validUntil": "2026-05-24T04:12:38Z"
     }
   ]
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -5,7 +5,7 @@
       "fetch": "https://transparency.meta.com/sr/dsa-sra_results_report-2024-instagram#pdf"
     },
     "Systemic Risks — 2025": {
-      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An8XcdaHXXjKc6ezrgbQR9yoq0DMmtPQrTijRe8MaU67fncOrw-rcDUNuuP0lfpTLGr3aWtYkKlpqwYW6sbYnLPPJHucxd0m4JR00vEuxj1vz7TPa_bKxrrnUCfFz0Jr-Wv0Ibs?_nc_gid=vI6JC0DrhAYrto-79RvMwA&_nc_oc=AdrENnQCME4XvD4qyiEbcRtLiwnjDqrfpEICxtu8z2z_3TYCFkDO8ydww13hbrN0Urk&ccb=10-5&oh=00_Af6SSxrui4wgoDdyBg18dWvnkfQcT72X_zGcSB3WGdiLHw&oe=6A0E3353&_nc_sid=68f2c3#pdf"
+      "fetch": "https://scontent.flyn1-1.fna.fbcdn.net/m1/v/t0.84174-6/An8XcdaHXXjKc6ezrgbQR9yoq0DMmtPQrTijRe8MaU67fncOrw-rcDUNuuP0lfpTLGr3aWtYkKlpqwYW6sbYnLPPJHucxd0m4JR00vEuxj1vz7TPa_bKxrrnUCfFz0Jr-Wv0Ibs?_nc_gid=QAut1O1izJ9OebxgGgBIrg&_nc_oc=Adqs-ly3Le1rL2eTaEOR7sXLsfDrNfVt5QQLoMD6Y0ZY4DjsIiMBaWxu6A4QHQsU1Avnn2dEz_Y_usBRbWcbqXey&ccb=10-5&oh=00_Af9IVVjZVs7aTvN9VZqo8KYc1nyZVQi5BF6vdgAzTzuNsg&oe=6A3C1F93&_nc_sid=68f2c3#pdf"
     }
   }
 }


### PR DESCRIPTION
Meta serves these reports only through expiring signed fbcdn.net URLs with no stable permalink, so the declared fetch URL returns HTTP 403 within some days and the tracking issues are reopens.